### PR TITLE
Fix/init data race

### DIFF
--- a/lib/mondrian_rest/api_helpers.rb
+++ b/lib/mondrian_rest/api_helpers.rb
@@ -8,32 +8,31 @@ module Mondrian::REST
     @@mdx_parser = nil
 
     def olap
-      @@olap
       if @@olap.nil?
         raise 'Please create mondrian connection and .connect in config.ru'
       end
+      @@olap
     end
 
     ##
     # Returns an instance of org.olap4j.mdx.parser.MdxParser
     def mdx_parser
       if @@mdx_parser.nil?
-        @@mdx_parser = olap.raw_connection.getParserFactory
-                       .createMdxParser(olap.raw_connection)
+        raise 'Please create mondrian mdx parser'
       end
       @@mdx_parser
     end
 
     def olap_flush
-      if olap.connected?
-        olap.flush_schema_cache
-        olap.close
+      if @@olap.connected?
+        @@olap.flush_schema_cache
+        @@olap.close
       end
-      olap.connect
+      @@olap.connect
     end
 
     def get_cube_or_404(name)
-      cube = olap.cube(name)
+      cube = @@olap.cube(name)
       error!('Not found', 404) if cube.nil?
       cube
     end

--- a/lib/mondrian_rest/api_helpers.rb
+++ b/lib/mondrian_rest/api_helpers.rb
@@ -11,6 +11,7 @@ module Mondrian::REST
       @@olap
       if @@olap.nil?
         raise 'Please create mondrian connection and .connect in config.ru'
+      end
     end
 
     ##

--- a/lib/mondrian_rest/api_helpers.rb
+++ b/lib/mondrian_rest/api_helpers.rb
@@ -4,15 +4,13 @@ module Mondrian::REST
   end
 
   module APIHelpers
-    @@olap = nil
+    @@olap = nil # env['mondrian-olap.conn']
     @@mdx_parser = nil
 
     def olap
-      if @@olap.nil?
-        @@olap = Mondrian::OLAP::Connection.new(env['mondrian-olap.params'])
-        @@olap.connect
-      end
       @@olap
+      if @@olap.nil?
+        raise 'Please create mondrian connection and .connect in config.ru'
     end
 
     ##


### PR DESCRIPTION
@jazzido @jspeis just wanted to start the conversation about patching the race condition on connection init.

As far as I can tell, this patch fixes NilClass errors that were occurring when there were near-simultaneous requests to MondrianRest.

Previously, constructing the connection and connecting occurred on the first api request. Since connecting took some time, there would be a moment when `@@olap` was no longer nil, but the new mondrian connection was not yet ready for use (resulting in, we think, the `NilClass` errors).

With this patch, now those initialization steps are done in the config.ru.

```ruby
mondrian_conn = Mondrian::OLAP::Connection.new(PARAMS)
mondrian_conn.connect
Mondrian::REST::APIHelpers.class_variable_set('@@olap', mondrian_conn)

use Rack::Config do |env|
  env['mondrian-olap.conn'] = mondrian_conn
end
```

There's probably a better way to do this, so please let us know what you think @jazzido . This would be a pretty big breaking change if it had to be done in `config.ru`