### PR TITLE
uses crossjoin instead of *

### DIFF
--- a/lib/mondrian_rest/query_helper.rb
+++ b/lib/mondrian_rest/query_helper.rb
@@ -265,7 +265,15 @@ module Mondrian::REST
 
       unless dd.empty?
         # Cross join all the drilldowns
-        axis_exp = dd.join(' * ')
+        axis_exp = if dd.size == 1
+                     dd
+                   else dd.size > 1
+                     cross = "Crossjoin(#{dd.pop(2).join(', ')})"
+                     while !dd.empty?
+                       cross = "Crossjoin(#{dd.pop}, #{cross})"
+                     end
+                     cross
+                   end
 
         # Apply filters
         unless filters.empty?

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -189,7 +189,7 @@ describe "Cube API" do
       get '/cubes/Sales/aggregate?drilldown[]=Time.Month&drilldown[]=Customers.City&measures[]=Store%20Sales&debug=true'
       r = JSON.parse(last_response.body)
       expect(r.has_key?('mdx')).to be(true)
-      expect(r['mdx']).to eq("SELECT {[Measures].[Store Sales]} ON COLUMNS,\n[Time].[Time].[Month].Members * [Customers].[Customers].[City].Members ON ROWS\nFROM [Sales]")
+      expect(r['mdx']).to eq("SELECT {[Measures].[Store Sales]} ON COLUMNS,\nCrossjoin([Time].[Time].[Month].Members, [Customers].[Customers].[City].Members) ON ROWS\nFROM [Sales]")
     end
 
     it "should not include the generated MDX in the response if debug not given or if debug=false" do


### PR DESCRIPTION
Seems that Mondrian's `*` is less performant than `Crossjoin`.